### PR TITLE
Update links following repository name change

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -69,7 +69,7 @@ jobs:
                 with:
                     auth: ${{ secrets.GIST_SECRET }}
                     gistID: 5ceb08845fe95635fc41af2f4c86c631
-                    filename: php-ext-jsonpath__${{ env.BRANCH_NAME }}.json
+                    filename: pecl-jsonpath__${{ env.BRANCH_NAME }}.json
                     label: Coverage
                     message: ${{ env.COVERAGE }}
                     color: green

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # JsonPath-PHP - extension for PHP 7.4+
 
-[![Build status](https://github.com/supermetrics-public/php-ext-jsonpath/workflows/Build/badge.svg)](https://github.com/supermetrics-public/php-ext-jsonpath/actions?query=workflow%3ABuild)
-![Code coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/crocodele/5ceb08845fe95635fc41af2f4c86c631/raw/php-ext-jsonpath__main.json&labelColor=343940)
+[![Build status](https://github.com/supermetrics-public/pecl-jsonpath/workflows/Build/badge.svg)](https://github.com/supermetrics-public/pecl-jsonpath/actions?query=workflow%3ABuild)
+![Code coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/crocodele/5ceb08845fe95635fc41af2f4c86c631/raw/pecl-jsonpath__main.json&labelColor=343940)
 
 JSONPath is a language for querying and extracting data from JSON, similar to XPath for XML.
 
@@ -279,5 +279,5 @@ make lint-code
 JsonPath-PHP is created by [Mike Kaminski](https://github.com/mkaminski1988) and maintained by 
 [Supermetrics](https://github.com/supermetrics-public) and Mike Kaminski.
 
-Found a bug, or missing some feature? [Raise an issue](https://github.com/supermetrics-public/php-ext-jsonpath/issues) or
-[submit a pull request](https://github.com/supermetrics-public/php-ext-jsonpath/pulls).
+Found a bug, or missing some feature? [Raise an issue](https://github.com/supermetrics-public/pecl-jsonpath/issues) or
+[submit a pull request](https://github.com/supermetrics-public/pecl-jsonpath/pulls).


### PR DESCRIPTION
Relates to https://github.com/supermetrics-public/pecl-jsonpath/pull/128 and the PHP license terms.