### PR TITLE
Perform clang-format check automatically on pushes to the repository

### DIFF
--- a/.github/workflows/clang_format_lint.yml
+++ b/.github/workflows/clang_format_lint.yml
@@ -1,0 +1,15 @@
+name: Run lint check with clang-format
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: DoozyX/clang-format-lint-action@v0.12
+        with:
+          source: './jsonpath.c ./php_jsonpath.h ./src/jsonpath'
+          extensions: 'c,h'
+          clangFormatVersion: 12


### PR DESCRIPTION
Fixes https://github.com/supermetrics-public/pecl-jsonpath/issues/125.