### PR TITLE
Add missing config.w32 entry to package.xml to make PECL builds on Windows possible

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,7 @@
  <contents>
   <dir name="/">
    <file name="config.m4" role="src"/>
+   <file name="config.w32" role="src"/>
    <file name="jsonpath.c" role="src"/>
    <file name="jsonpath.stub.php" role="src"/>
    <file name="jsonpath_arginfo.h" role="src"/>


### PR DESCRIPTION
Should fix #135 on next PECL release.