### PR TITLE
Dereference values to always get the underlying value

### DIFF
--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -51,7 +51,6 @@ void eval_ast(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_
       copy_result_or_continue(arr_head, arr_cur, tok, return_value);
       break;
     case AST_RECURSE:
-      tok = tok->next;
       exec_recursive_descent(arr_head, arr_cur, tok, return_value);
       break;
     case AST_SELECTOR:
@@ -106,18 +105,16 @@ static void exec_wildcard(zval* arr_head, zval* arr_cur, struct ast_node* tok, z
 }
 
 static void exec_recursive_descent(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value) {
-  ZVAL_DEREF(arr_cur);
-
   if (arr_cur == NULL || Z_TYPE_P(arr_cur) != IS_ARRAY) {
     return;
   }
 
-  eval_ast(arr_head, arr_cur, tok, return_value);
+  eval_ast(arr_head, arr_cur, tok->next, return_value);
 
   zval* data;
 
   ZEND_HASH_FOREACH_VAL_IND(HASH_OF(arr_cur), data) {
-    exec_recursive_descent(arr_head, data, tok, return_value);
+    eval_ast(arr_head, data, tok, return_value);
   }
   ZEND_HASH_FOREACH_END();
 }

--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -33,6 +33,9 @@ void eval_ast(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_
   if (tok == NULL) {
     return;
   }
+
+  ZVAL_DEREF(arr_cur);
+
   switch (tok->type) {
     case AST_UNION_KEY:
       exec_node_filter(arr_head, arr_cur, tok, return_value);
@@ -103,6 +106,8 @@ static void exec_wildcard(zval* arr_head, zval* arr_cur, struct ast_node* tok, z
 }
 
 static void exec_recursive_descent(zval* arr_head, zval* arr_cur, struct ast_node* tok, zval* return_value) {
+  ZVAL_DEREF(arr_cur);
+
   if (arr_cur == NULL || Z_TYPE_P(arr_cur) != IS_ARRAY) {
     return;
   }

--- a/tests/references/001.phpt
+++ b/tests/references/001.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test dot notation for a node that is a reference
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => 42,
+];
+
+$another = [
+    "key" => 43,
+];
+
+$data["another"] =& $another;
+
+$jsonPath = new \JsonPath\JsonPath();
+
+$result = $jsonPath->find($data, "$.another.key");
+
+var_dump($result);
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  int(43)
+}

--- a/tests/references/002.phpt
+++ b/tests/references/002.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test bracket notation for a node that is a reference
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => 42,
+];
+
+$another = [
+    "key" => 43,
+];
+
+$data["another"] =& $another;
+
+$jsonPath = new \JsonPath\JsonPath();
+
+$result = $jsonPath->find($data, "$['another']['key']");
+
+var_dump($result);
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  int(43)
+}

--- a/tests/references/003.phpt
+++ b/tests/references/003.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Test array slice notation for a node that is a reference
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => 42,
+];
+
+$another = [
+    43,
+    44,
+    45,
+];
+
+$data["another"] =& $another;
+
+$jsonPath = new \JsonPath\JsonPath();
+
+$result = $jsonPath->find($data, "$.another[1::]");
+
+var_dump($result);
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  int(44)
+  [1]=>
+  int(45)
+}

--- a/tests/references/004.phpt
+++ b/tests/references/004.phpt
@@ -1,0 +1,36 @@
+--TEST--
+Test filter with a node that is a reference
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => 42,
+];
+
+$another = [
+    [
+        "key" => 43,
+    ],
+    [
+        "key" => 53,
+    ],
+];
+
+$data["another"] =& $another;
+
+$jsonPath = new \JsonPath\JsonPath();
+
+$result = $jsonPath->find($data, "$.another[?(@.key <= 50)]");
+
+var_dump($result);
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  array(1) {
+    ["key"]=>
+    int(43)
+  }
+}

--- a/tests/references/005.phpt
+++ b/tests/references/005.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Test wildcard with a node that is a reference
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => 42,
+];
+
+$another = [
+    "key" => 43,
+];
+
+$data["another"] =& $another;
+
+$jsonPath = new \JsonPath\JsonPath();
+
+$result = $jsonPath->find($data, "$.another.*");
+
+var_dump($result);
+?>
+--EXPECT--
+array(1) {
+  [0]=>
+  int(43)
+}

--- a/tests/references/006.phpt
+++ b/tests/references/006.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Test recursive descent with a node that is a reference
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$data = [
+    "key" => 42,
+];
+
+$another = [
+    "key" => 43,
+];
+
+$data["another"] =& $another;
+
+$jsonPath = new \JsonPath\JsonPath();
+
+$result = $jsonPath->find($data, "$..['key']");
+
+var_dump($result);
+?>
+--EXPECT--
+array(2) {
+  [0]=>
+  int(42)
+  [1]=>
+  int(43)
+}


### PR DESCRIPTION
Fixes #150, based on info in https://www.phpinternalsbook.com/php7/zvals/references.html.