### PR TITLE
Fix Windows builds

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -3,4 +3,5 @@ ARG_ENABLE('jsonpath', 'enable JSONPath support', 'no');
 if (PHP_JSONPATH != 'no') {
 	AC_DEFINE('HAVE_JSONPATH', 1, 'JSONPath support enabled')
 	EXTENSION('jsonpath', 'jsonpath.c', null, '/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1');
+	ADD_SOURCES(configure_module_dirname + '/src/jsonpath', 'exceptions.c lexer.c parser.c interpreter.c', 'jsonpath');
 }

--- a/src/jsonpath/interpreter.c
+++ b/src/jsonpath/interpreter.c
@@ -287,11 +287,11 @@ static bool compare_rgxp(zval* lh, zval* rh) {
   ZVAL_NULL(&retval);
   ZVAL_NULL(&subpats);
 
-  zend_string* s_lh = zend_string_copy(Z_STR_P(lh));
+  zend_string* zs_lh = zend_string_copy(Z_STR_P(lh));
 
-  php_pcre_match_impl(pce, s_lh, &retval, &subpats, 0, 0, 0, 0);
+  php_pcre_match_impl(pce, zs_lh, &retval, &subpats, 0, 0, 0, 0);
 
-  zend_string_release_ex(s_lh, 0);
+  zend_string_release_ex(zs_lh, 0);
   zval_ptr_dtor(&subpats);
 
   return Z_LVAL(retval) > 0;


### PR DESCRIPTION
First, we need to compile the ancillary files in the src/ directory.

Then we also need to cater to the local variable `s_lh`, what is
already defined as macro in WinSock2.h.  We could undefine that macro,
but just renaming the variable to `zs_lh` appears to be a good solution
either.