### PR TITLE
Include PHP 8.2 nightly as a version for test runs on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.4, 8.0, 8.1]
+                php: [7.4, 8.0, 8.1, 8.2]
                 use-opcache: [true, false]
 
         steps:


### PR DESCRIPTION
shivammathur/setup-php (Linux) [supports PHP 8.2](https://github.com/shivammathur/setup-php#tada-php-support).

cmb69/setup-php-sdk (Windows) doesn't seem to support PHP 8.2 nightlies yet.