### PR TITLE
Issue #164 - refactor string unescaping

### DIFF
--- a/jsonpath.c
+++ b/jsonpath.c
@@ -39,19 +39,14 @@ PHP_METHOD(JsonPath_JsonPath, find) {
     return;
   }
 
-  /* Keep the original parameter untouched for the stack trace and instead work with a copy that might be modified
-   * during processing, e.g. due to escaped quotes in string literals */
-  char* j_path_work_copy = estrdup(j_path);
-
   /* tokenize JSON-path string */
 
   struct jpath_token lex_tok[LEX_TOK_ARR_LEN];
   int lex_tok_count = 0;
 
-  bool scan_ok = scan_tokens(j_path_work_copy, lex_tok, &lex_tok_count);
+  bool scan_ok = scan_tokens(j_path, lex_tok, &lex_tok_count);
 
   if (!scan_ok) {
-    efree(j_path_work_copy);
     return;
   }
 
@@ -66,7 +61,6 @@ PHP_METHOD(JsonPath_JsonPath, find) {
   struct ast_node* head = parse_jsonpath(lex_tok, &i, lex_tok_count, &pool);
 
   if (head == NULL) {
-    efree(j_path_work_copy);
     free_php_objects(&pool);
     return;
   }
@@ -81,7 +75,6 @@ PHP_METHOD(JsonPath_JsonPath, find) {
 
   eval_ast(search_target, search_target, head, return_value);
 
-  efree(j_path_work_copy);
   free_php_objects(&pool);
 
   /* return false if no results were found by the JSON-path query */

--- a/src/jsonpath/lexer.h
+++ b/src/jsonpath/lexer.h
@@ -5,33 +5,34 @@
 #include <stddef.h>
 
 typedef enum {
-  LEX_AND,             /* && */
-  LEX_CHILD_SEP,       /* , */
-  LEX_CUR_NODE,        /* @ */
-  LEX_DEEP_SCAN,       /* .. */
-  LEX_EQ,              /* == */
-  LEX_EXPR_END,        /* ] */
-  LEX_EXPR_START,      /* ? */
-  LEX_FILTER_START,    /* [ */
-  LEX_GT,              /* > */
-  LEX_GTE,             /* >= */
-  LEX_LITERAL,         /* "some string" 'some string' */
-  LEX_LITERAL_BOOL,    /* true, false */
-  LEX_LITERAL_NULL,    /* null */
-  LEX_LITERAL_NUMERIC, /* int, float */
-  LEX_LT,              /* < */
-  LEX_LTE,             /* <= */
-  LEX_NEGATION,        /* !@.value */
-  LEX_NEQ,             /* != */
-  LEX_NODE,            /* .child, ['child'] */
-  LEX_NOT_FOUND,       /* Token not found */
-  LEX_OR,              /* || */
-  LEX_PAREN_CLOSE,     /* ) */
-  LEX_PAREN_OPEN,      /* ( */
-  LEX_RGXP,            /* =~ */
-  LEX_ROOT,            /* $ */
-  LEX_SLICE,           /* : */
-  LEX_WILD_CARD,       /* * */
+  LEX_AND,               /* && */
+  LEX_CHILD_SEP,         /* , */
+  LEX_CUR_NODE,          /* @ */
+  LEX_DEEP_SCAN,         /* .. */
+  LEX_EQ,                /* == */
+  LEX_EXPR_END,          /* ] */
+  LEX_EXPR_START,        /* ? */
+  LEX_FILTER_START,      /* [ */
+  LEX_GT,                /* > */
+  LEX_GTE,               /* >= */
+  LEX_LITERAL,           /* "some string" 'some string' */
+  LEX_LITERAL_BOOL,      /* true, false */
+  LEX_LITERAL_NULL,      /* null */
+  LEX_LITERAL_NUMERIC,   /* int, float */
+  LEX_LITERAL_UNESCAPED, /* "some \"string\"" 'some \'string\'' */
+  LEX_LT,                /* < */
+  LEX_LTE,               /* <= */
+  LEX_NEGATION,          /* !@.value */
+  LEX_NEQ,               /* != */
+  LEX_NODE,              /* .child, ['child'] */
+  LEX_NOT_FOUND,         /* Token not found */
+  LEX_OR,                /* || */
+  LEX_PAREN_CLOSE,       /* ) */
+  LEX_PAREN_OPEN,        /* ( */
+  LEX_RGXP,              /* =~ */
+  LEX_ROOT,              /* $ */
+  LEX_SLICE,             /* : */
+  LEX_WILD_CARD,         /* * */
 } lex_token;
 
 struct jpath_token {

--- a/tests/issues/00164.phpt
+++ b/tests/issues/00164.phpt
@@ -1,0 +1,58 @@
+--TEST--
+Test escaped quotes in selectors and string literals
+--DESCRIPTION--
+https://github.com/supermetrics-public/pecl-jsonpath/issues/164
+--SKIPIF--
+<?php if (!extension_loaded("jsonpath")) print "skip"; ?>
+--FILE--
+<?php
+
+$obj = [
+    'store' => [
+        'book' => [
+            [
+                'category' => 'reference',
+                'title' => 'Sayings of the Century',
+                "the 'author'" => "Nigel 'Rees'",
+            ],
+            [
+                'category' => 'fiction',
+                'title' => 'Sword of Honour',
+                'the "author"' => 'Evelyn "Waugh"',
+            ],
+            [
+                'category' => 'fiction',
+                'title' => 'Moby Dick',
+                "the 'author'" => 'Herman Melville',
+            ],
+            [
+                'category' => 'fiction',
+                'title' => 'The Lord of the Rings',
+                'the "author"' => 'J. R. R. Tolkien',
+            ]
+        ]
+    ]
+];
+
+$jsonPath = new \JsonPath\JsonPath();
+
+print_r($jsonPath->find($obj, '$.store.book[?(@["the \"author\""] == "Evelyn \"Waugh\"" || '."@['the \'author\''] == 'Nigel \'Rees\'')]"));
+
+--EXPECT--
+Array
+(
+    [0] => Array
+        (
+            [category] => reference
+            [title] => Sayings of the Century
+            [the 'author'] => Nigel 'Rees'
+        )
+
+    [1] => Array
+        (
+            [category] => fiction
+            [title] => Sword of Honour
+            [the "author"] => Evelyn "Waugh"
+        )
+
+)


### PR DESCRIPTION
This PR removes the string duplication (and string allocation) that occurs upon invoking `jsonpath()`, which was previously used to solve the [escaped string edge case](https://github.com/supermetrics-public/pecl-jsonpath/blob/main/tests/comparison_bracket_notation/025.phpt).

**Before**
`jsonpath()` duplicates the input string and passes it to the lexer. The lexer removes slashes from the string.

**After**
The lexer assigns tokens containing escaped characters the `LEX_LITERAL_UNESCAPED` type. When the parser encounters `LEX_LITERAL_UNESCAPED`, it runs the built-in `php_stripcslashes()` function on the allocated string.

I've also added a test that ensures string literal unescaping works. The existing tests in `tests/comparison_bracket_notation` only ensure that unescaping works on selectors.