### PR TITLE
relax test for 8.3

### DIFF
--- a/tests/comparison_root/003_php8.phpt
+++ b/tests/comparison_root/003_php8.phpt
@@ -14,7 +14,7 @@ $result = $jsonPath->find($data, "$");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: JsonPath\JsonPath::find(): Argument #1 ($data) must be of type array, bool given in %s003_php8.php:%d
+Fatal error: Uncaught TypeError: JsonPath\JsonPath::find(): Argument #1 ($data) must be of type array, %s given in %s003_php8.php:%d
 Stack trace:
 %s
 %s

--- a/tests/comparison_root/004_php8.phpt
+++ b/tests/comparison_root/004_php8.phpt
@@ -14,7 +14,7 @@ $result = $jsonPath->find($data, "$");
 var_dump($result);
 ?>
 --EXPECTF--
-Fatal error: Uncaught TypeError: JsonPath\JsonPath::find(): Argument #1 ($data) must be of type array, bool given in %s004_php8.php:%d
+Fatal error: Uncaught TypeError: JsonPath\JsonPath::find(): Argument #1 ($data) must be of type array, %s given in %s004_php8.php:%d
 Stack trace:
 %s
 %s


### PR DESCRIPTION
Without this

```
========DIFF========
001- Fatal error: Uncaught TypeError: JsonPath\JsonPath::find(): Argument #1 ($data) must be of type array, bool given in %s003_php8.php:%d
001+ Fatal error: Uncaught TypeError: JsonPath\JsonPath::find(): Argument #1 ($data) must be of type array, false given in /dev/shm/BUILD/php83-php-pecl-jsonpath-1.0.0/NTS/tests/comparison_root/003_php8.php:6
     Stack trace:
     %s
     %s
--
========DONE========
FAIL Test root on scalar false [tests/comparison_root/003_php8.phpt] 

========DIFF========
001- Fatal error: Uncaught TypeError: JsonPath\JsonPath::find(): Argument #1 ($data) must be of type array, bool given in %s004_php8.php:%d
001+ Fatal error: Uncaught TypeError: JsonPath\JsonPath::find(): Argument #1 ($data) must be of type array, true given in /dev/shm/BUILD/php83-php-pecl-jsonpath-1.0.0/NTS/tests/comparison_root/004_php8.php:6
     Stack trace:
     %s
     %s
--
========DONE========
FAIL Test root on scalar true [tests/comparison_root/004_php8.phpt] 

```