### PR TITLE
Test with PHP 8.3 on Windows, unify naming and formatting in workflow files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.0, 8.1, 8.2, 8.3, 8.4 ]
-        use-opcache: [ true, false ]
+        php: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
+        use-opcache: [ "true", "false" ]
 
     steps:
       - name: Checkout jsonpath

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
+        php: [ "8.0", "8.1", "8.2", "8.3" ]
         use-opcache: [ "true", "false" ]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,54 +1,55 @@
-name: Build
+name: Build and test on Linux
 
 on:
-    push:
-        branches: [main]
-    pull_request:
-    release:
-        types: [created]
+  push:
+    branches: [ main ]
+  pull_request:
+  release:
+    types: [ created ]
 
 jobs:
-    tests:
-        runs-on: ubuntu-latest
-        name: Build and test
-        strategy:
-            fail-fast: false
-            matrix:
-                php: [8.0, 8.1, 8.2, 8.3]
-                use-opcache: [true, false]
+  tests:
+    runs-on: ubuntu-latest
+    name: Build and test
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ 8.0, 8.1, 8.2, 8.3, 8.4 ]
+        use-opcache: [ true, false ]
 
-        steps:
-            -   uses: actions/checkout@v2
+    steps:
+      - name: Checkout jsonpath
+        uses: actions/checkout@v2
 
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: "${{ matrix.php }}"
-                    coverage: none
-                    tools: pecl
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "${{ matrix.php }}"
+          coverage: none
+          tools: pecl
 
-            -   name: Compile
-                run: ./.build-scripts/compile.sh
+      - name: Compile jsonpath
+        run: ./.build-scripts/compile.sh
 
-            -   name: Find PHP
-                run: |
-                    TEST_PHP_EXECUTABLE=`make findphp`
-                    echo "Found PHP in: $TEST_PHP_EXECUTABLE"
-                    echo "TEST_PHP_EXECUTABLE=$TEST_PHP_EXECUTABLE" >> $GITHUB_ENV
-          
-            -   name: Define PHP arguments
-                run: |
-                    TEST_PHP_ARGS="-n"
-                    [[ "${{ matrix.use-opcache }}" != "true" ]] || TEST_PHP_ARGS="$TEST_PHP_ARGS -d zend_extension=opcache.so -d opcache.enable=1 -d opcache.enable_cli=1"
-                    TEST_PHP_ARGS="$TEST_PHP_ARGS -d extension=$PWD/modules/jsonpath.so"
-                    echo "Test PHP arguments: $TEST_PHP_ARGS"
-                    echo "TEST_PHP_ARGS=$TEST_PHP_ARGS" >> $GITHUB_ENV
-          
-            -   name: Run tests
-                run: |
-                    $TEST_PHP_EXECUTABLE $TEST_PHP_ARGS -v
-                    $TEST_PHP_EXECUTABLE -n run-tests.php -q -x --show-diff
+      - name: Find PHP
+        run: |
+          TEST_PHP_EXECUTABLE=`make findphp`
+          echo "Found PHP in: $TEST_PHP_EXECUTABLE"
+          echo "TEST_PHP_EXECUTABLE=$TEST_PHP_EXECUTABLE" >> $GITHUB_ENV
 
-            -   name: Show errors
-                if: ${{ failure() }}
-                run: ./.build-scripts/show-errors.sh
+      - name: Define PHP arguments
+        run: |
+          TEST_PHP_ARGS="-n"
+          [[ "${{ matrix.use-opcache }}" != "true" ]] || TEST_PHP_ARGS="$TEST_PHP_ARGS -d zend_extension=opcache.so -d opcache.enable=1 -d opcache.enable_cli=1"
+          TEST_PHP_ARGS="$TEST_PHP_ARGS -d extension=$PWD/modules/jsonpath.so"
+          echo "Test PHP arguments: $TEST_PHP_ARGS"
+          echo "TEST_PHP_ARGS=$TEST_PHP_ARGS" >> $GITHUB_ENV
+
+      - name: Run jsonpath tests
+        run: |
+          $TEST_PHP_EXECUTABLE $TEST_PHP_ARGS -v
+          $TEST_PHP_EXECUTABLE -n run-tests.php -q -x --show-diff
+
+      - name: Show errors
+        if: ${{ failure() }}
+        run: ./.build-scripts/show-errors.sh

--- a/.github/workflows/clang_format_lint.yml
+++ b/.github/workflows/clang_format_lint.yml
@@ -1,14 +1,18 @@
 name: Run lint check with clang-format
 
-on: [push]
+on:
+  push:
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: DoozyX/clang-format-lint-action@v0.12
+      - name: Checkout jsonpath
+        uses: actions/checkout@v2
+
+      - name: Perform linting
+        uses: DoozyX/clang-format-lint-action@v0.12
         with:
           source: './jsonpath.c ./php_jsonpath.h ./src/jsonpath'
           extensions: 'c,h'

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ 8.3 ]
+        php: [ "8.3" ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -1,75 +1,75 @@
 name: Calculate code coverage
 
 on:
-    push:
-        branches: [main]
+  push:
+    branches: [ main ]
 
 jobs:
-    tests:
-        runs-on: ubuntu-latest
-        name: Build, run tests with code coverage, create badge
-        strategy:
-            fail-fast: false
-            matrix:
-                php: [8.0]
+  tests:
+    runs-on: ubuntu-latest
+    name: Build, run tests with code coverage, create badge
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ 8.3 ]
 
-        steps:
-            -   uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-            -   name: Get branch name (merge)
-                if: github.event_name != 'pull_request'
-                shell: bash
-                run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+      - name: Get branch name (merge)
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
 
-            -   name: Get branch name (pull request)
-                if: github.event_name == 'pull_request'
-                shell: bash
-                run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
+      - name: Get branch name (pull request)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | tr / -)" >> $GITHUB_ENV
 
-            -   name: Install lcov
-                run: sudo apt-get -y install lcov
+      - name: Install lcov
+        run: sudo apt-get -y install lcov
 
-            -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
-                with:
-                    php-version: "${{ matrix.php }}"
-                    coverage: none
-                    tools: pecl
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "${{ matrix.php }}"
+          coverage: none
+          tools: pecl
 
-            -   name: Compile with code coverage support
-                run: ./.build-scripts/compile-coverage.sh
+      - name: Compile with code coverage support
+        run: ./.build-scripts/compile-coverage.sh
 
-            -   name: Find PHP
-                run: |
-                    TEST_PHP_EXECUTABLE=`make findphp`
-                    echo "Found PHP in: $TEST_PHP_EXECUTABLE"
-                    echo "TEST_PHP_EXECUTABLE=$TEST_PHP_EXECUTABLE" >> $GITHUB_ENV
-          
-            -   name: Define PHP arguments
-                run: |
-                    TEST_PHP_ARGS="-n"
-                    TEST_PHP_ARGS="$TEST_PHP_ARGS -d extension=$PWD/modules/jsonpath.so"
-                    echo "Test PHP arguments: $TEST_PHP_ARGS"
-                    echo "TEST_PHP_ARGS=$TEST_PHP_ARGS" >> $GITHUB_ENV
-          
-            -   name: Run tests
-                run: |
-                    $TEST_PHP_EXECUTABLE $TEST_PHP_ARGS -v
-                    $TEST_PHP_EXECUTABLE -n run-tests.php -q -x --show-diff
+      - name: Find PHP
+        run: |
+          TEST_PHP_EXECUTABLE=`make findphp`
+          echo "Found PHP in: $TEST_PHP_EXECUTABLE"
+          echo "TEST_PHP_EXECUTABLE=$TEST_PHP_EXECUTABLE" >> $GITHUB_ENV
 
-            -   name: Generate code coverage report
-                run: |
-                    COVERAGE=$(make lcov-summary |& grep 'lines...' | grep -Eo ' [0-9.]+' | xargs | awk '{print $1}' | xargs printf "%.*f\n" 0)
-                    COVERAGE="${COVERAGE}%"
-                    echo "Code coverage (lines): $COVERAGE"
-                    echo "COVERAGE=$COVERAGE" >> $GITHUB_ENV
-            
-            -   name: Create the badge
-                uses: schneegans/dynamic-badges-action@v1.0.0
-                with:
-                    auth: ${{ secrets.GIST_SECRET }}
-                    gistID: 5ceb08845fe95635fc41af2f4c86c631
-                    filename: pecl-jsonpath__${{ env.BRANCH_NAME }}.json
-                    label: Coverage
-                    message: ${{ env.COVERAGE }}
-                    color: green
+      - name: Define PHP arguments
+        run: |
+          TEST_PHP_ARGS="-n"
+          TEST_PHP_ARGS="$TEST_PHP_ARGS -d extension=$PWD/modules/jsonpath.so"
+          echo "Test PHP arguments: $TEST_PHP_ARGS"
+          echo "TEST_PHP_ARGS=$TEST_PHP_ARGS" >> $GITHUB_ENV
+
+      - name: Run tests
+        run: |
+          $TEST_PHP_EXECUTABLE $TEST_PHP_ARGS -v
+          $TEST_PHP_EXECUTABLE -n run-tests.php -q -x --show-diff
+
+      - name: Generate code coverage report
+        run: |
+          COVERAGE=$(make lcov-summary |& grep 'lines...' | grep -Eo ' [0-9.]+' | xargs | awk '{print $1}' | xargs printf "%.*f\n" 0)
+          COVERAGE="${COVERAGE}%"
+          echo "Code coverage (lines): $COVERAGE"
+          echo "COVERAGE=$COVERAGE" >> $GITHUB_ENV
+
+      - name: Create the badge
+        uses: schneegans/dynamic-badges-action@v1.0.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: 5ceb08845fe95635fc41af2f4c86c631
+          filename: pecl-jsonpath__${{ env.BRANCH_NAME }}.json
+          label: Coverage
+          message: ${{ env.COVERAGE }}
+          color: green

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,11 +37,14 @@ jobs:
           arch: ${{matrix.arch}}
           toolset: ${{steps.setup-php.outputs.toolset}}
 
+      - name: Run phpize for jsonpath
+        run: phpize
+
+      - name: Run configure for jsonpath
+        run: configure --enable-jsonpath --with-prefix=${{steps.setup-php.outputs.prefix}}
+
       - name: Compile jsonpath
-        run: |
-          phpize \
-          && configure --enable-jsonpath --with-prefix=${{steps.setup-php.outputs.prefix}} \
-          && nmake
+        run: nmake
 
       - name: Run jsonpath tests
         run: nmake test TESTS="-j2 --show-diff -g FAIL,BORK,WARN,LEAK tests"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,36 +1,47 @@
-name: Build and Test
-on: [push, pull_request]
+name: Build and test on Windows
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  release:
+    types: [ created ]
+
 jobs:
-  build:
+  tests:
+    runs-on: windows-2019
+    name: Build and test
     defaults:
       run:
         shell: cmd
     strategy:
       matrix:
-          version: ['8.0', '8.1', '8.2']
-          arch: [x64]
-          ts: [ts]
-    runs-on: windows-2019
+        version: [ 8.0, 8.1, 8.2, 8.3 ]
+        arch: [ x64 ]
+        ts: [ ts ]
     steps:
       - name: Checkout jsonpath
         uses: actions/checkout@v2
+
       - name: Setup PHP
         id: setup-php
-        uses: cmb69/setup-php-sdk@v0.6
+        uses: php/setup-php-sdk@v0.8
         with:
           version: ${{matrix.version}}
           arch: ${{matrix.arch}}
           ts: ${{matrix.ts}}
+
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{matrix.arch}}
           toolset: ${{steps.setup-php.outputs.toolset}}
-      - name: phpize
-        run: phpize
-      - name: configure
-        run: configure --enable-jsonpath --with-prefix=${{steps.setup-php.outputs.prefix}}
-      - name: make
-        run: nmake
-      - name: test
+
+      - name: Compile jsonpath
+        run: |
+          phpize \
+          && configure --enable-jsonpath --with-prefix=${{steps.setup-php.outputs.prefix}} \
+          && nmake
+
+      - name: Run jsonpath tests
         run: nmake test TESTS="-j2 --show-diff -g FAIL,BORK,WARN,LEAK tests"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -16,9 +16,9 @@ jobs:
         shell: cmd
     strategy:
       matrix:
-        version: [ 8.0, 8.1, 8.2, 8.3 ]
-        arch: [ x64 ]
-        ts: [ ts ]
+        version: [ "8.0", "8.1", "8.2", "8.3" ]
+        arch: [ "x64" ]
+        ts: [ "ts" ]
     steps:
       - name: Checkout jsonpath
         uses: actions/checkout@v2


### PR DESCRIPTION
Probably easiest to review with whitespace changes hidden.

- For Windows builds, changing the action from `cmb69/setup-php-sdk` to its successor (?) `php/setup-php-sdk`, which supports PHP 8.3 builds.
- Code coverage build is done with latest stable, i.e. PHP 8.3.