### PR TITLE
Test also on PHP 8.4 for Windows and PHP 8.5 (nightly) for Linux, cache PHP-SDK in Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
+        php: [ "8.0", "8.1", "8.2", "8.3", "8.4", "8.5" ]
         use-opcache: [ "true", "false" ]
 
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -9,14 +9,14 @@ on:
 
 jobs:
   tests:
-    runs-on: windows-2019
+    runs-on: windows-2022
     name: Build and test
     defaults:
       run:
         shell: cmd
     strategy:
       matrix:
-        version: [ "8.0", "8.1", "8.2", "8.3" ]
+        version: [ "8.0", "8.1", "8.2", "8.3", "8.4" ]
         arch: [ "x64" ]
         ts: [ "ts" ]
     steps:
@@ -30,6 +30,7 @@ jobs:
           version: ${{matrix.version}}
           arch: ${{matrix.arch}}
           ts: ${{matrix.ts}}
+          cache: true
 
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1


### PR DESCRIPTION
- PHP 8.4 requires a newer image than windows-2019, so let's try switching to windows-2022.
- php/setup-php-sdk@v0.10 introduced a cache option. Let's try it out.